### PR TITLE
Fix USB error with Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -43,6 +43,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.annotation:annotation:1.1.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.7'
-    implementation 'com.starmicronics:stario:2.8.0'
-    implementation 'com.starmicronics:starioextension:1.14.0'
+    implementation 'com.starmicronics:stario:2.11.1'
+    implementation 'com.starmicronics:starioextension:1.15.1'
 }


### PR DESCRIPTION
There is an issue with these dependency versions, which prevent printing via USB. The port discovery does not return any printers. Updating this dependency resolves the issue.